### PR TITLE
fix: add rustfmt and clippy components to crates.io publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,6 +384,10 @@ jobs:
         cache: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
     
+    - name: Install Rust components
+      run: |
+        rustup component add rustfmt clippy
+    
     - name: Get version from tag
       id: version
       run: |


### PR DESCRIPTION
## Summary
- Fix crates.io publish workflow that was failing due to missing rustfmt component
- Add explicit installation of rustfmt and clippy components before running quality checks

## Problem
The publish to crates.io job was failing with:
```
error: 'cargo-fmt' is not installed for the toolchain '1.88.0-x86_64-unknown-linux-gnu'.
```

## Solution
Added explicit installation of Rust components before running the quality checks:
```yaml
- name: Install Rust components
  run: |
    rustup component add rustfmt clippy
```

This ensures the required tools are available in the CI environment.

## Test Plan
- [x] Workflow syntax is valid
- [ ] Next release will verify the fix works correctly