### PR TITLE
chore: trigger patch release with workflow fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,7 @@ jobs:
     - name: Install Rust components
       run: |
         rustup component add rustfmt clippy
+        echo "Components installed successfully"
     
     - name: Get version from tag
       id: version


### PR DESCRIPTION
## Summary
Triggering a patch release to include the rustfmt fix and properly publish to crates.io.

## Changes
- Minor update to workflow to ensure the fix is included
- This will trigger v0.7.2 release with working crates.io publication

## Release Notes for v0.7.2
- Fixed crates.io publish workflow by adding rustfmt and clippy components
- No functional changes to the application

This patch release ensures that future releases can be properly published to crates.io.