### PR TITLE
fix: clarify Cargo installation method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A terminal UI for monitoring and managing Celery workers and tasks, inspired by 
 
 Choose your preferred installation method:
 
-### 🦀 Cargo (Rust)
+### 🦀 Cargo (Rust package manager)
 
 ```bash
 cargo install lazycelery


### PR DESCRIPTION
## Summary
Minor documentation fix to clarify that Cargo is the Rust package manager.

This will trigger a patch release (v0.7.2) that includes:
- The rustfmt/clippy fix for crates.io publishing
- This minor documentation improvement

## Changes
- Updated README to clarify 'Cargo (Rust package manager)' instead of just 'Cargo (Rust)'

This ensures the v0.7.2 release will be properly published to crates.io with the workflow fixes.